### PR TITLE
add deep linking support

### DIFF
--- a/BaseApi.js
+++ b/BaseApi.js
@@ -46,6 +46,7 @@ const endpoints = {
   ideas: baseApiUrl + '/modules/$moduleId/ideas/',
   idea: baseApiUrl + '/modules/$moduleId/ideas/$ideaPk/',
   login: baseApiUrl + '/login/',
+  project: baseApiUrl + '/app-projects/$project',
   module: baseApiUrl + '/app-modules/$moduleId/',
   projects: baseApiUrl + '/app-projects/',
   ratings: baseApiUrl + '/contenttypes/$contentTypeId/objects/$objectPk/ratings/',
@@ -166,6 +167,10 @@ const API = {
   },
   getProjects(token = null) {
     return makeGetRequest(endpoints.projects, token)
+  },
+  getProject(token, project) {
+    const url = endpoints.project.replace('$project', project)
+    return makeGetRequest(url, token)
   },
   getModule(moduleId, token = null) {
     const url = endpoints.module.replace('$moduleId', moduleId)

--- a/app.json
+++ b/app.json
@@ -3,6 +3,7 @@
     "name": "liqd-demo",
     "owner": "liquiddemocracyev",
     "slug": "liqd-demo",
+    "scheme": "liqd",
     "version": "1.0.0",
     "privacy": "unlisted",
     "orientation": "portrait",
@@ -25,7 +26,21 @@
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#FFFFFF"
-      }
+      },
+       "intentFilters": [
+        {
+          "action": "VIEW",
+          "data": [
+            {
+              "scheme": "https",
+              "host": "aplus-dev.liqd.net",
+              "pathPrefix": ""
+            }
+          ],
+          "category": ["BROWSABLE", "DEFAULT"]
+        }
+      ],
+      "package": "net.liqd.demo.app"
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/containers/Auth/AuthProvider.js
+++ b/containers/Auth/AuthProvider.js
@@ -1,9 +1,10 @@
-import React, {useEffect, useMemo } from 'react'
+import React from 'react'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 
 const AuthContext = React.createContext({
   loading: true,
   token: null,
+  deepLink: null,
   signIn: () => {},
   signOut: () => {},
 })
@@ -20,8 +21,9 @@ export const AuthProvider = (props) => {
   const [state, setState] = React.useState({
     loading: true,
     token: null,
+    deepLink: null
   })
-  useEffect(() => {
+  React.useEffect(() => {
     const tryLogin = async () => {
       const authToken = await AsyncStorage.getItem('authToken')
       setState({
@@ -33,7 +35,7 @@ export const AuthProvider = (props) => {
     tryLogin()
   }, [])
 
-  const actions = useMemo(() => ({
+  const actions = React.useMemo(() => ({
     signIn: async (authToken) => {
       AsyncStorage.setItem('authToken', authToken)
       setState({ ...state, loading: false, token: authToken })
@@ -42,6 +44,9 @@ export const AuthProvider = (props) => {
       AsyncStorage.removeItem('authToken')
       setState({ ...state, loading: false, token: null })
     },
+    setDeepLink: (projectSlug) => {
+      setState({...state, deepLink: projectSlug})
+    }
   }))
   return (
     <AuthContext.Provider value={{ ...state, ...actions }}>

--- a/navigation/DeepLinking.js
+++ b/navigation/DeepLinking.js
@@ -1,0 +1,22 @@
+import React, { useEffect } from 'react'
+import { useAuthorization } from '../containers/Auth/AuthProvider.js'
+import { View } from 'react-native'
+
+export const DeepLinking = (props) => {
+  const { loading, token, setDeepLink } = useAuthorization()
+
+  useEffect(() => {
+    if(loading){
+      return
+    }
+    setDeepLink(props.route.params.projectSlug)
+    if (token === null) {
+      props.navigation.replace('Auth')
+    } else {
+      props.navigation.replace('ExplorePage')
+    }
+
+  }, [loading, props.route.params])
+
+  return <View></View>
+}

--- a/navigation/IdeaNavigator.js
+++ b/navigation/IdeaNavigator.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { NavigationContainer } from '@react-navigation/native'
 import { createStackNavigator } from '@react-navigation/stack'
+import * as Linking from 'expo-linking'
 import { ExplorePage } from '../containers/Ideas/ExplorePage'
 import { Idea } from '../containers/Ideas/Idea'
 import { IdeaCreate } from '../containers/Ideas/IdeaCreate'
@@ -13,8 +14,18 @@ import { ReportCreateMessage } from '../containers/Reports/ReportCreateMessage'
 import { ProfileScreen } from '../containers/User/ProfileScreen'
 import { SettingsOverview } from '../containers/User/SettingsOverview'
 import { SettingsProfile } from '../containers/User/SettingsProfile'
+import { DeepLinking } from './DeepLinking.js'
 
 const Stack = createStackNavigator()
+const prefix = Linking.createURL('/')
+const linking = {
+  prefixes: [prefix, 'https://aplus-dev.liqd.net/'],
+  config: {
+    screens: {
+      DeepLinking: '/:organisation/projects/:projectSlug/',
+    }
+  }
+}
 
 export const IdeaNavigator = () => {
   const { loading, token } = useAuthorization()
@@ -41,12 +52,13 @@ export const IdeaNavigator = () => {
   }
 
   return (
-    <NavigationContainer>
+    <NavigationContainer linking={linking}>
       <Stack.Navigator
         initialRouteName="StartUp"
         screenOptions={{ gestureEnabled: false, headerShown: false }}
       >
         {stackScreen}
+        <Stack.Screen name="DeepLinking" component={DeepLinking} />
       </Stack.Navigator>
     </NavigationContainer>
   )

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "expo-font": "10.1.0",
     "expo-image-picker": "13.1.1",
     "expo-linear-gradient": "11.3.0",
+    "expo-linking": "^3.1.0",
     "expo-permissions": "13.2.0",
     "expo-splash-screen": "0.15.1",
     "expo-status-bar": "1.3.0",


### PR DESCRIPTION
* Adds react-navigation (in preparation for deep linking)
* Adds support for deep linking

Can be tested with `npx uri-scheme open exp://127.0.0.1:19000/--/rines-test-orga/projects/appy-idea-challenge/ --android`

In theory this will also ask a user clicking https://aplus-dev.liqd.net/rines-test-orga/projects/appy-idea-challenge/ whether they want to open it in the app. For this to work the app needs to be a standalone app though - which it currently isn't (I did also test it as standalone app and it worked).