### PR TITLE
module/ideas: projects without images have primary color as bg

### DIFF
--- a/containers/Ideas/ExploreListItem.js
+++ b/containers/Ideas/ExploreListItem.js
@@ -8,7 +8,7 @@ import IconSLI from 'react-native-vector-icons/SimpleLineIcons';
 export const ExploreListItem = (props) => {
   const image = props.item.image
     ? props.item.image
-    : 'https://i.imgur.com/o4L0arH.jpg';
+    : '';
 
   return (
     <TouchableOpacity onPress={() => props.action(props.item)}>
@@ -58,6 +58,7 @@ const styles = StyleSheet.create({
   image: {
     flex: 1,
     resizeMode: 'cover',
+    backgroundColor: COLORS.primary
   },
   textContainer: {
     padding: SPACINGS.multiplyBy(0.8),

--- a/containers/Ideas/IdeaProject.js
+++ b/containers/Ideas/IdeaProject.js
@@ -17,7 +17,7 @@ export const IdeaProject = (props) => {
   const [phaseEnd, setPhaseEnd] = useState();
   const bgImage = project.image
     ? project.image
-    : 'https://i.imgur.com/o4L0arH.jpg';
+    : '';
   const singleModule = project.single_agenda_setting_module;
 
   const pressHandler = () =>

--- a/containers/Ideas/IdeaProject.styles.js
+++ b/containers/Ideas/IdeaProject.styles.js
@@ -13,6 +13,7 @@ export const styles = StyleSheet.create({
   bgImage: {
     flex: 1,
     resizeMode: 'cover',
+    backgroundColor: COLORS.primary
   },
   overlayContainer: {
     borderTopLeftRadius: 24,


### PR DESCRIPTION
After checking with @mcastro-lqd we use the brand primary color (as is on the web version) as default to show in case the project does not have an image.