### PR TITLE
BaseApi: add rating functionality

### DIFF
--- a/BaseApi.js
+++ b/BaseApi.js
@@ -4,7 +4,8 @@ const endpoints = {
   ideas: baseUrl + '/modules/$moduleId/ideas/',
   login: baseUrl + '/login/',
   projects: baseUrl + '/app-projects/',
-  modules: baseUrl + '/app-modules/'
+  modules: baseUrl + '/app-modules/',
+  rate: baseUrl + '/contenttypes/$contentTypeId/objects/$objectPk/ratings/'
 };
 
 const makeGetRequest = (url) => {
@@ -42,6 +43,23 @@ const makePostRequest = (url, data = {}, token=null) => {
     .catch(error => console.error(error));
 };
 
+const makePutRequest = (url, data = {}, token=null) => {
+  return fetch(url, {
+    method: 'PUT',
+    headers: getHeaders(token),
+    body: JSON.stringify(data)
+  })
+    .then(response => {
+      const statusCode = response.status;
+      const data = response.json();
+      return Promise.all([statusCode, data]);
+    })
+    .then(values => {
+      return {'statusCode': values[0], 'data': values[1]};
+    })
+    .catch(error => console.error(error));
+};
+
 const API = {
   getIdeas(moduleId) {
     const url = endpoints.ideas.replace(/\$(\w+?)\b/g, moduleId);
@@ -63,6 +81,16 @@ const API = {
   getModule(moduleId) {
     const url = endpoints.modules + moduleId;
     return makeGetRequest(url);
+  },
+  rate(contentTypeId, objectPk, data, token=null) {
+    const ct_url = endpoints.rate.replace('$contentTypeId', contentTypeId);
+    const url = ct_url.replace('$objectPk', objectPk);
+    return makePostRequest(url, data, token);
+  },
+  changeRating(contentTypeId, objectPk, ratingId, data, token=null) {
+    const ct_url = endpoints.rate.replace('$contentTypeId', contentTypeId);
+    const url = ct_url.replace('$objectPk', objectPk) + ratingId +'/';
+    return makePutRequest(url, data, token);
   }
 };
 


### PR DESCRIPTION
I hope this works, couldnt really test it :grimacing: 

For both rate and changeRating the data is just the value of the rating, so data = {value: 1} or data = {value: -1}. When a rating is removed, it is handled by submitting {value: 0}.

For rating, only objectId is needed, for changeRating also the ratingId is needed, which is now serialized, see https://github.com/liqd/adhocracy-plus/pull/1373