### PR TITLE
app/idea-edit: fix freeze after editing idea

### DIFF
--- a/containers/Ideas/Idea.js
+++ b/containers/Ideas/Idea.js
@@ -27,7 +27,7 @@ export const Idea = (props) => {
       title: 'Edit',
       icon: 'pencil',
       action: () =>  {
-        toggleMenu();
+        setMenuVisible(false);
         props.navigation.navigate('IdeaCreate', {idea: ideaState, project: project, editing: true});
       },
       isFirst: true,
@@ -49,7 +49,7 @@ export const Idea = (props) => {
     },
     {
       title: 'Cancel',
-      action: () => toggleMenu(),
+      action: () => setMenuVisible(false),
       isCancel: true,
       isAllowed: true
     },

--- a/containers/Ideas/Idea.js
+++ b/containers/Ideas/Idea.js
@@ -26,7 +26,10 @@ export const Idea = (props) => {
     {
       title: 'Edit',
       icon: 'pencil',
-      action: () =>  props.navigation.navigate('IdeaCreate', {idea: ideaState, project: project, editing: true}),
+      action: () =>  {
+        toggleMenu();
+        props.navigation.navigate('IdeaCreate', {idea: ideaState, project: project, editing: true});
+      },
       isFirst: true,
       isAllowed: ideaState.has_changing_permission
     },


### PR DESCRIPTION
@Rineee this should fix the freezing of the screen after editing an idea. Due to the menu is not closed after clicking on edit it is still there but not visible. It blocks everything. tricky. maybe the menu should close automatically to avoid this bug in future.