### PR TITLE
fix bug with dependency react-native-reanimated

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "jest",
     "testDebug": "jest -o --coverage=false",
     "testNoCov": "jest --coverage=false",
-    "updateSnapshots": "jest -u --coverage=false"
+    "updateSnapshots": "jest -u --coverage=false",
+    "postinstall": "patch-package"
   },
   "jest": {
     "preset": "jest-expo",
@@ -72,7 +73,8 @@
     "eslint-plugin-react-native": "4.0.0",
     "husky": "7.0.4",
     "jest-expo": "44.0.1",
-    "lint-staged": "12.1.4"
+    "lint-staged": "12.1.4",
+    "patch-package": "^6.4.7"
   },
   "private": true,
   "lint-staged": {

--- a/patches/react-native-reanimated+2.3.1.patch
+++ b/patches/react-native-reanimated+2.3.1.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/react-native-reanimated/src/reanimated2/core.ts b/node_modules/react-native-reanimated/src/reanimated2/core.ts
+index 2e0c38a..025fe44 100644
+--- a/node_modules/react-native-reanimated/src/reanimated2/core.ts
++++ b/node_modules/react-native-reanimated/src/reanimated2/core.ts
+@@ -383,8 +383,10 @@ if (!NativeReanimatedModule.useOnlyV1) {
+         info: runOnJS(capturableConsole.info),
+       };
+       _setGlobalConsole(console);
+-      global.performance = {
+-        now: global._chronoNow,
++      if (global.performance == null) {
++        global.performance = {
++          now: global._chronoNow,
++        };
+       };
+     })();
+   }


### PR DESCRIPTION
@phillimorland @goapunk I encountered another bug, while using the current versions of our dependencies.
this time it was a known bug with the package `react-native-reanimated`.

There is the option to downgrade that particular package/dependency, but people reported version issues with other dependencies. So I tried another option, which is to patch a file of that dependency (solution provided 5 days ago, the time i am writing this). And it worked.

source: https://github.com/gorhom/react-native-bottom-sheet/issues/771

For this to work I had to install another dependency called `patch-package` (gosh!). But at the end this makes it work.

`...those of us living on the bleeding edge.` - npm readme of patch-package