### PR TITLE
api: include release-channels in api url selection

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,7 @@
   "ignorePatterns": ["**/__mocks__/*"],
   "rules": {
       // General ESLINT rules
-      "indent": ["error", 2],
+      "indent": ["error", 2, {"SwitchCase": 1}],
       "linebreak-style": ["error", "unix"],
       "quotes": ["error", "single"],
       "semi": ["error", "always"],

--- a/BaseApi.js
+++ b/BaseApi.js
@@ -13,7 +13,16 @@ const baseUrl = (() => {
     return 'https://aplus-dev.liqd.net/api';
   }
   else {
-    return 'https://adhocracy.plus/api';
+    switch (Constants.manifest.releaseChannel) {
+      case 'prod':
+      case 'default':
+        return 'https://adhocracy.plus/api';
+      case 'stage':
+        return 'https://aplus-stage.liqd.net/api';
+      case 'dev':
+      default:
+        return 'https://aplus-dev.liqd.net/api';
+    }
   }
 })();
 


### PR DESCRIPTION
I forgot to add cases for the release-channels we publish to. This should fix the login again.
I also added an eslint rule which stops the complaining about the switch-case, I couldn't get it to accept the code otherwise with a sane indentation