### PR TITLE
Jd 2022 06 comments editable

### DIFF
--- a/BaseApi.js
+++ b/BaseApi.js
@@ -177,6 +177,12 @@ const API = {
     const url = ct_url.replace('$objectPk', objectPk);
     return makePostRequest(url, data, token);
   },
+  editComment(contentTypeId, objectPk, commentPk, data, token = null) {
+    const ct_url = endpoints.comment.replace('$contentTypeId', contentTypeId);
+    const ct_obj_url = ct_url.replace('$objectPk', objectPk);
+    const url = ct_obj_url.replace('$commentPk', commentPk);
+    return makePutRequest(url, data, token);
+  },
   deleteComment(contentTypeId, objectPk, commentPk, token = null) {
     const ct_url = endpoints.comment.replace('$contentTypeId', contentTypeId);
     const ct_obj_url = ct_url.replace('$objectPk', objectPk);

--- a/containers/Comments/Comment.js
+++ b/containers/Comments/Comment.js
@@ -24,7 +24,7 @@ export const Comment = (props) => {
     {
       title: 'Edit',
       icon: 'pencil',
-      action: () => console.log('Edit comment'),
+      action: () => props.toggleEditing(commentBeingProcessed),
       isFirst: true,
       isAllowed: comment.user_info.has_changing_permission
     },
@@ -88,6 +88,18 @@ export const Comment = (props) => {
   const onTextLayout = useCallback(e => {
     setHasExcerpt(e.nativeEvent.lines.length > NUM_OF_LINES);
   }, []);
+
+  function handleOptions(subcomment) {
+    if (subcomment !== undefined){
+      setCommentBeingProcessed(subcomment);
+    }
+    else {
+      setCommentBeingProcessed(comment);
+    }
+    props.setDeleteModalItems(commentDeleteModalItems);
+    props.setMenuItems(commentMenuItems);
+    props.toggleMenu();
+  }
 
   const handleRate = async(ratingComment, value) => {
     if (processing) return;
@@ -198,7 +210,7 @@ export const Comment = (props) => {
           <Button
             icon={optionsIcon}
             type='clear'
-            onPress={() => {setCommentBeingProcessed(comment); props.toggleMenu();}}
+            onPress={() => handleOptions()}
           />
         </TextSourceSans>
         }
@@ -274,7 +286,7 @@ export const Comment = (props) => {
         <SubComments
           comments={comment.child_comments}
           handleRate={handleRate}
-          setCommentBeingProcessed={setCommentBeingProcessed}
+          handleOptions={handleOptions}
           toggleMenu={props.toggleMenu}
           getCommentTextDisplay={getCommentTextDisplay}
           isDisplayed={isDisplayed}

--- a/containers/Comments/CommentForm.js
+++ b/containers/Comments/CommentForm.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, TextInput, TouchableOpacity } from 'react-native';
 import { Formik } from 'formik';
 import * as yup from 'yup';
@@ -8,7 +8,6 @@ import { COLORS } from '../../theme/colors';
 import { SIZES } from '../../theme/fonts';
 
 export const CommentForm = (props) => {
-
   const commentValidationSchema = yup.object().shape({
     comment: yup
       .string()
@@ -33,31 +32,37 @@ export const CommentForm = (props) => {
         errors,
         touched,
         isValid,
-      }) => (
-        <View style={styles.submitContainer}>
-          <View style={styles.textInputContainer}>
-            <TextInput
-              name='comment'
-              ref={props.inputRef}
-              value={values.comment}
-              placeholder='Enter your comment'
-              onChangeText={handleChange('comment')}
-              onBlur={handleBlur('comment')}
-              error={errors.comment}
-              touched={touched.comment}
-              multiline
-            />
+        setFieldValue
+      }) => {
+        useEffect(() => {
+          setFieldValue('comment', props.value, false);
+        }, [props.isEdit]);
+        return (
+          <View style={styles.submitContainer}>
+            <View style={styles.textInputContainer}>
+              <TextInput
+                name='comment'
+                ref={props.inputRef}
+                value={values.comment}
+                placeholder='Enter your comment'
+                onChangeText={handleChange('comment')}
+                onBlur={handleBlur('comment')}
+                error={errors.comment}
+                touched={touched.comment}
+                multiline
+              />
+            </View>
+            <View style={styles.submitButton}>
+              <TouchableOpacity
+                onPress={handleSubmit}
+                disabled={!isValid}
+              >
+                {planeIcon}
+              </TouchableOpacity>
+            </View>
           </View>
-          <View style={styles.submitButton}>
-            <TouchableOpacity
-              onPress={handleSubmit}
-              disabled={!isValid}
-            >
-              {planeIcon}
-            </TouchableOpacity>
-          </View>
-        </View>
-      )}
+        );
+      }}
     </Formik>
   );
 };

--- a/containers/Comments/Comments.js
+++ b/containers/Comments/Comments.js
@@ -19,6 +19,7 @@ export const Comments = (props) => {
           openSubComments={(props.commentLastCommented==comment.id) ? true : false}
           setMenuItems={props.setMenuItems}
           toggleMenu={props.toggleMenu}
+          toggleEditing={props.toggleEditing}
           setDeleteModalItems={props.setDeleteModalItems}
           toggleDeleteModal={props.toggleDeleteModal}
           hasCommentingPermission={props.hasCommentingPermission}

--- a/containers/Comments/SubComment.js
+++ b/containers/Comments/SubComment.js
@@ -51,7 +51,7 @@ export const SubComment = (props) => {
           <Button
             icon={optionsIcon}
             type='clear'
-            onPress={() => {props.setCommentBeingProcessed(comment); props.toggleMenu();}}
+            onPress={() => props.handleOptions(comment)}
           />
         </TextSourceSans>
         }

--- a/containers/Comments/SubComments.js
+++ b/containers/Comments/SubComments.js
@@ -10,7 +10,7 @@ export const SubComments = (props) => {
           key={`comment-${comment.id}`}
           comment={comment}
           handleRate={props.handleRate}
-          setCommentBeingProcessed={props.setCommentBeingProcessed}
+          handleOptions={props.handleOptions}
           toggleMenu={props.toggleMenu}
           getCommentTextDisplay={props.getCommentTextDisplay}
           isDisplayed={props.isDisplayed}

--- a/containers/Ideas/Idea.js
+++ b/containers/Ideas/Idea.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Alert, View, Image, ScrollView, Platform, KeyboardAvoidingView } from 'react-native';
+import { Alert, View, Image, ScrollView, Platform, KeyboardAvoidingView, Pressable } from 'react-native';
 import { Button } from '@rneui/base';
 import { styles } from './Idea.styles';
 import IconSLI from 'react-native-vector-icons/SimpleLineIcons';
@@ -320,76 +320,78 @@ export const Idea = (props) => {
         onScroll={handleScroll}
         contentContainerStyle={styles.contentContainer}
       >
-        <View style={styles.titleContainer}>
-          <TextSourceSans style={styles.title}>{ideaState.name}</TextSourceSans>
-        </View>
-        <View style={styles.descriptionContainer}>
-          {ideaState.image && (
-            <>
-              <Image source={{ uri: ideaState.image }} style={styles.ideaImage} />
-            </>
-          )}
-          <TextSourceSans style={styles.text}>{ideaState.description}</TextSourceSans>
-        </View>
-        {getLabels().length > 0 && (
-          <View style={styles.labelsContainer}>
-            {getLabels().map((label, idx) => (
-              <Label key={idx + label} title={label} />
-            ))}
+        <Pressable onPress={isEditing && toggleEditing} style={{
+          ...isEditing ? {opacity: 0.25, backgroundColor: '#fff'}: {}
+        }} disabled={!isEditing}>
+          <View style={styles.titleContainer}>
+            <TextSourceSans style={styles.title}>{ideaState.name}</TextSourceSans>
           </View>
-        )}
-        <View style={styles.infoContainer}>
-          <TextSourceSans style={styles.creator}>
-            {ideaState.creator} {DateService(idea.created)}
-          </TextSourceSans>
-          <TextSourceSans style={styles.text}>
+          <View style={styles.descriptionContainer}>
+            {ideaState.image && (
+              <>
+                <Image source={{ uri: ideaState.image }} style={styles.ideaImage} />
+              </>
+            )}
+            <TextSourceSans style={styles.text}>{ideaState.description}</TextSourceSans>
+          </View>
+          {getLabels().length > 0 && (
+            <View style={styles.labelsContainer}>
+              {getLabels().map((label, idx) => (
+                <Label key={idx + label} title={label} />
+              ))}
+            </View>
+          )}
+          <View style={styles.infoContainer}>
+            <TextSourceSans style={styles.creator}>
+              {ideaState.creator} {DateService(idea.created)}
+            </TextSourceSans>
+            <TextSourceSans style={styles.text}>
             Reference No.: {ideaState.reference_number || 'n/a'}
-          </TextSourceSans>
-        </View>
-        <View style={styles.bottomActionsContainer}>
-          <View style={styles.ratingButtons}>
-            <ButtonCounter
-              icon={arrowUpIcon}
-              counter={ideaState.positive_rating_count}
-              onPress={() => handleRate(1)}
-              highlight={
-                ideaState.user_rating &&
+            </TextSourceSans>
+          </View>
+          <View style={styles.bottomActionsContainer}>
+            <View style={styles.ratingButtons}>
+              <ButtonCounter
+                icon={arrowUpIcon}
+                counter={ideaState.positive_rating_count}
+                onPress={() => handleRate(1)}
+                highlight={
+                  ideaState.user_rating &&
                 ideaState.user_rating.value === 1 &&
                 ideaState.user_rating.value
-              }
-              disabled={!ideaState.has_rating_permission}
-            />
-            <ButtonCounter
-              icon={arrowDownIcon}
-              counter={ideaState.negative_rating_count}
-              onPress={() => handleRate(-1)}
-              highlight={
-                ideaState.user_rating &&
+                }
+                disabled={!ideaState.has_rating_permission}
+              />
+              <ButtonCounter
+                icon={arrowDownIcon}
+                counter={ideaState.negative_rating_count}
+                onPress={() => handleRate(-1)}
+                highlight={
+                  ideaState.user_rating &&
                 ideaState.user_rating.value === -1 &&
                 ideaState.user_rating.value
-              }
-              disabled={!ideaState.has_rating_permission}
+                }
+                disabled={!ideaState.has_rating_permission}
+              />
+            </View>
+            <View>
+              {commentIcon}
+            </View>
+          </View>
+          {comments && <View>
+            <Comments
+              comments={comments}
+              handleReply={handleCommentReply}
+              commentLastCommented={commentLastCommented}
+              setMenuItems={setMenuItems}
+              toggleMenu={toggleMenu}
+              toggleEditing={toggleEditing}
+              setDeleteModalItems={setDeleteModalItems}
+              toggleDeleteModal={toggleDeleteModal}
+              hasCommentingPermission={idea.has_commenting_permission}
             />
-          </View>
-          <View>
-            {commentIcon}
-          </View>
-        </View>
-        {comments && <View style={{
-          ...isEditing ? {opacity: 0.25, backgroundColor: '#fff'}: {}
-        }}>
-          <Comments
-            comments={comments}
-            handleReply={handleCommentReply}
-            commentLastCommented={commentLastCommented}
-            setMenuItems={setMenuItems}
-            toggleMenu={toggleMenu}
-            toggleEditing={toggleEditing}
-            setDeleteModalItems={setDeleteModalItems}
-            toggleDeleteModal={toggleDeleteModal}
-            hasCommentingPermission={idea.has_commenting_permission}
-          />
-        </View>}
+          </View>}
+        </Pressable>
       </ScrollView>
       {idea.has_commenting_permission && (
         <View>

--- a/containers/Ideas/Idea.js
+++ b/containers/Ideas/Idea.js
@@ -321,7 +321,7 @@ export const Idea = (props) => {
         contentContainerStyle={styles.contentContainer}
       >
         <Pressable onPress={isEditing && toggleEditing} style={{
-          ...isEditing ? {opacity: 0.25, backgroundColor: '#fff'}: {}
+          ...isEditing ? styles.pressableEditing : {}
         }} disabled={!isEditing}>
           <View style={styles.titleContainer}>
             <TextSourceSans style={styles.title}>{ideaState.name}</TextSourceSans>

--- a/containers/Ideas/Idea.js
+++ b/containers/Ideas/Idea.js
@@ -23,6 +23,7 @@ export const Idea = (props) => {
   const [comments, setComments] = useState([]);
   const [contentObjectOfComment, setContentObjectOfComment] = useState({'contentType': idea.content_type, 'pk': idea.pk});
   const [commentLastCommented, setCommentLastCommented] = useState(-1);
+  const [isScrolling, setIsScrolling] = useState(false);
   const hasComments = comments.length !== 0;
   const commentInputRef = useRef(null);
   const ideaMenuItems = [
@@ -167,6 +168,19 @@ export const Idea = (props) => {
     commentInputRef.current.focus();
   };
 
+  function handleBack() {
+    return props.navigation.goBack();
+  }
+
+  function handleScroll(event) {
+    if (isScrolling && event.nativeEvent.contentOffset.y < 75.0) {
+      setIsScrolling(false);
+    }
+    else if (!isScrolling && (event.nativeEvent.contentOffset.y >= 75.0) ) {
+      setIsScrolling(true);
+    }
+  }
+
   const fetchIdea = () => {
     return AsyncStorage.getItem('authToken')
       .then((token) => API.getIdea(module.pk, ideaState.pk, token))
@@ -231,10 +245,7 @@ export const Idea = (props) => {
       behavior={(Platform.OS === 'ios')? 'padding' : null}
       style={{flex:1}}
     >
-      <ScrollView
-        style={styles.container}
-        contentContainerStyle={styles.contentContainer}
-      >
+      <View style={styles.container}>
         <View style={styles.actionsContainer}>
           <Button
             buttonStyle={styles.backButton}
@@ -242,14 +253,21 @@ export const Idea = (props) => {
             title='Back'
             type='clear'
             icon={arrowLeftIcon}
-            onPress={() => props.navigation.goBack()}
+            onPress={handleBack}
           />
-          <Button
-            icon={optionsIcon}
-            type='clear'
-            onPress={() => {setMenuItems(ideaMenuItems); toggleMenu();}}
-          />
+          {!isScrolling &&
+        <Button
+          icon={optionsIcon}
+          type='clear'
+          onPress={() => {setMenuItems(ideaMenuItems); toggleMenu();}}
+        />}
         </View>
+      </View>
+      <ScrollView
+        style={styles.container}
+        onScroll={handleScroll}
+        contentContainerStyle={styles.contentContainer}
+      >
         <View style={styles.titleContainer}>
           <TextSourceSans style={styles.title}>{ideaState.name}</TextSourceSans>
         </View>

--- a/containers/Ideas/Idea.styles.js
+++ b/containers/Ideas/Idea.styles.js
@@ -1,14 +1,13 @@
 import { StyleSheet } from 'react-native';
 import { COLORS } from '../../theme/colors';
 import { SIZES, FONTWEIGHT } from '../../theme/fonts';
-import { SPACINGS, BORDERRADIUS } from '../../theme/spacings';
+import { SPACINGS } from '../../theme/spacings';
 
 export const styles = StyleSheet.create({
   fontColor: {
     color: COLORS.text.main,
   },
   container: {
-    paddingBottom: SPACINGS.multiplyBy(2),
     paddingHorizontal: SPACINGS.multiplyBy(.75),
     backgroundColor: COLORS.paper.main,
   },
@@ -23,8 +22,8 @@ export const styles = StyleSheet.create({
     justifyContent: 'flex-end'
   },
   actionsContainer: {
-    height: SPACINGS.multiplyBy(4),
     marginTop: SPACINGS.multiplyBy(2),
+    marginBottom: SPACINGS.multiplyBy(1),
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',

--- a/containers/Ideas/Idea.styles.js
+++ b/containers/Ideas/Idea.styles.js
@@ -90,5 +90,9 @@ export const styles = StyleSheet.create({
   commentIcon: {
     fontSize: SIZES.md,
     marginVertical: SPACINGS.multiplyBy(.5),
+  },
+  pressableEditing: {
+    opacity: 0.25,
+    backgroundColor: '#fff'
   }
 });


### PR DESCRIPTION
* make header (back button and settings button) sticky when scrolling (so you can cancel the editing, ~~we don't seem to handle taps yet, tapping somewhere on the screen above the form should also cancel it, this is a TODO~~, same for hardware back button on android and swipe gesture on iOS?)
*  add Pressable which cancels editing mode if you press outside the input and applies the transparent grey overlay
* make settings button for Idea editing disappear on scrolling (not sure if this is what we want? The settings button wasn't in the design but that could have bee because it's not from admin/initiator view?)
* make comments editable