### PR TITLE
containers/Auth: also show field errors

### DIFF
--- a/containers/Auth/LoginScreen.js
+++ b/containers/Auth/LoginScreen.js
@@ -22,7 +22,18 @@ export const LoginScreen = () => {
   const handleLogin = (values) => {
     API.postLogin(values).then((response) => {
       if (response.statusCode!==200) {
-        setError(response.data.non_field_errors[0]);
+        if (response.data.non_field_errors) {
+          setError(response.data.non_field_errors[0]);
+        }
+        else if (response.data.username) {
+          setError('Username: ' + response.data.username[0]);
+        }
+        else if (response.data.password) {
+          setError('Password: ' + response.data.password[0]);
+        }
+        else {
+          setError('Something went wrong, please try again.');
+        }
       }
       else {
         signIn(response.data.token);


### PR DESCRIPTION
We did actually already show the only error, I could find that could appear in the app. We do make sure in the app that we don't send an empty username or password. I still added the errors for the two fields we have, in case there are other errors that the user would otherwise miss. 
If you want to test password or username errors, you need to remove lines 34-39 and the `disabled={!isValid}` from the button.